### PR TITLE
Added multidevice support to Pushover notifications

### DIFF
--- a/DomotiGa3/.src/Events.module
+++ b/DomotiGa3/.src/Events.module
@@ -490,7 +490,7 @@ End
 ' JSON              | 16                 | deviceid                  | post/get             | url
 ' send Prowl        | 17                 | prowl message to send
 ' send NMA          | 18                 | nma message to send
-' send Pushover     | 19                 | pushover message to send  | optional priority    | optional sound
+' send Pushover     | 19                 | pushover message to send  | optional priority    | optional sound       | Devices list
 ' send Pushbullet   | 20                 | pushbullet message to send| optional title (default 'DomotiGa') | optional deviceid ('all' for all devices)
 
 ' Action to be run. If iAction=0 then cData has to be applied and it will be a "manual" action.
@@ -499,7 +499,7 @@ Public Sub RunAction(iAction As Integer, iOrder As Integer, iEventId As Integer,
 
   Dim rResultAction As Result
   Dim bOk As Boolean
-  Dim sResult, sName, sParam1, sParam2, sParam3, sParam4 As String
+  Dim sResult, sName, sParam1, sParam2, sParam3, sParam4, sDev As String
   Dim iType As Integer
 
   ' When action is zero, we get the type, param1, etc passed in the cData
@@ -658,7 +658,13 @@ Public Sub RunAction(iAction As Integer, iOrder As Integer, iEventId As Integer,
     Case 19 ' send Pushover
       ' TODO: Select instance
       If Plugin.IsPluginEnabled("Pushover", 0) Then
-        Plugin.GetPluginObject("Pushover", 1).Interface.PostPushover("", ParseText(sParam1), sParam2, sParam3)
+        If InStr(sParam4, ",")
+          For Each sDev In Split(sParam4, ",")
+            Plugin.GetPluginObject("Pushover", 1).Interface.PostPushover(LTrim(sDev), ParseText(sParam1), sParam2, sParam3)
+          Next
+        Else  
+          Plugin.GetPluginObject("Pushover", 1).Interface.PostPushover(sParam4, ParseText(sParam1), sParam2, sParam3)
+        Endif
       Else
         Error.Raise("Pushover support is disabled!")
       Endif

--- a/DomotiGa3/.src/FActionEditor.class
+++ b/DomotiGa3/.src/FActionEditor.class
@@ -207,6 +207,10 @@ Public Sub Form_Open()
           Else
             cmbPushoverSound.Text = rResult!param3
           Endif
+          
+          ' Destination Devices
+          txtPushoverDevices.Text = rResult!param4
+          
         Case 20 ' send pushbullet
           txtPushbulletMsg.Text = rResult!param1
           txtPushbulletTitle.Text = rResult!param2
@@ -496,6 +500,10 @@ Private Sub CheckTypeValues() As Collection
       ' Select sounds
       sParam3 = cmbPushoverSound[cmbPushoverSound.Index].Text
       If sParam3 = "pushover (default)" Then sParam3 = ""
+      
+      ' Select destination devices
+      sParam4 = txtPushoverDevices.Text
+      
     Case 20 ' send pushbullet message
       If Not txtPushbulletMsg.Text Then
         Balloon(("Please enter a Pushbullet message!"), txtPushbulletMsg)
@@ -1134,5 +1142,11 @@ Public Sub cmbPushbulletDevice_Change()
   Else
     txtPushbulletDeviceId.Text = ""
   Endif
+
+End
+
+Public Sub txtPushoverDevices_Change()
+
+  EnableButtons()
 
 End

--- a/DomotiGa3/.src/FActionEditor.form
+++ b/DomotiGa3/.src/FActionEditor.form
@@ -384,7 +384,7 @@
         Alignment = Align.Normal
       }
       { txtSendPushover TextArea
-        MoveScaled(12,2,52,12)
+        MoveScaled(12,2,52,8)
       }
       { lblSendProwlMessage4 TextLabel
         MoveScaled(2,15,9,3)
@@ -403,6 +403,10 @@
       { cmbPushoverSound ComboBox
         MoveScaled(39,15,25,3)
         ReadOnly = True
+      }
+      { txtPushoverDevices TextBox
+        MoveScaled(12,11,52,3)
+        Text = ("txtPushoverDevices")
       }
       Index = 19
       Text = ("Send Pushbullet")
@@ -469,5 +473,10 @@
     MoveScaled(30,46,12,4)
     ToolTip = ("Please save Action before running")
     Text = ("Run Now")
+  }
+  { lblPushoverDeviceList TextLabel
+    MoveScaled(4,35,9,3)
+    Text = ("Devices")
+    Alignment = Align.Normal
   }
 }

--- a/DomotiGa3/.src/Settings/FSettingsPushover.form
+++ b/DomotiGa3/.src/Settings/FSettingsPushover.form
@@ -36,7 +36,7 @@
     }
     { TextLblDevice TextLabel
       MoveScaled(2,15,17,3)
-      Text = ("Device")
+      Text = ("Default Device")
       Alignment = Align.Normal
     }
     { txtDevice TextBox


### PR DESCRIPTION
Hi there!

my first contribution via Git to a project, so I hope everything's OK!! 

I just added multidevice support to Pushover notificacions. Now you can specify a comma-separated list of Pushover registered devices that you want to receive the notification. If left blank, the notification will be displayed only in the "default device" you set on the Module Notifier settings.

With this in place, I can for example notify my wife's phone of the emergencies (alarm set off...) but not other trivial notifications (temperature of my den too high, my presence in the garage...).

Hope you like it!
