### PR TITLE
Fix incorrect function name for RFXComTRXRelay

### DIFF
--- a/DomotiGa3/.src/CRFXComTRX.class
+++ b/DomotiGa3/.src/CRFXComTRX.class
@@ -688,7 +688,7 @@ Public Sub RFXComTRXRelay_Connection(sHost As String)
 
 End
 
-Public Sub Socket_Read()
+Public Sub RFXComTRXRelay_Read()
 
   Dim sBuf As Byte
 
@@ -711,7 +711,7 @@ Public Sub RFXComTRXRelay_Error()
 
 End
 
-Public Sub Socket_Closed()
+Public Sub RFXComTRXRelay_Closed()
 
   Main.WriteLog(LogLabel & "Relay client connection closed.")
   hRelayTRXClient.Remove(hRelayTRXClient.Find(Last))


### PR DESCRIPTION
Had a look at CRFXComTRX and think some function names are incorrect although I am not 100% sure.

Also: It seems like nothing is done with the sBuf of Socket_Read/RFXComTRXRelay_Read is that correct?
