### PR TITLE
Fixed: Ported XMLRPC Thermostat DerogateHeating functions to JSONRPC

### DIFF
--- a/DomotiGa3/.src/CJSONRPC.class
+++ b/DomotiGa3/.src/CJSONRPC.class
@@ -2554,9 +2554,61 @@ End
 '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Private Sub Call_Thermostat_DerogateHeating(cData As Collection)
 
-  ' cData["scenario_id"] = CInt(iScenarioId)
-  ' cData["heating_id"] = CInt(iHeatingId)
-  ' cData["operator"] = JSONToEmptyString(sOperator)
+  Dim iScenarioId As Integer = CInt(cData["scenario_id"])
+  Dim iHeatingId As Integer = CInt(cData["heating_id"])
+  Dim fNewVal, fVal, fDerVal As Float
+
+  fVal = Thermostat.GetRequestedTempForHeating(iScenarioId, iHeatingId)
+  fDerVal = Thermostat.GetDerogateHeating(iHeatingId)
+  If fDerVal <> Thermostat.NO_TEMP Then
+    fval = fderval
+  Endif
+  If cData["operator"] = "+" Then
+    If fDerVal = Thermostat.NO_TEMP Then
+      fNewVal = Thermostat.GetNextRequestedTempForHeating(iScenarioId, iHeatingId)
+      If fNewVal <> Thermostat.NO_TEMP Then
+        If fNewVal < fval Then
+          fNewVal = fval + 0.5
+        Endif
+      Else
+        If fVal = Thermostat.NO_TEMP Then
+          Try fVal = Devices.GetCurrentValueForDevice(Thermostat.GetHeatSensor(iHeatingId), 1)
+        Endif
+
+        fNewVal = fval + 0.5
+      Endif
+    Else
+      fNewVal = fval + 0.5
+    Endif
+
+  Else If cData["operator"] = "-" Then
+
+    If fDerVal = Thermostat.NO_TEMP Then
+      fNewVal = Thermostat.GetNextRequestedTempForHeating(iScenarioId, iHeatingId)
+      If fNewVal <> Thermostat.NO_TEMP Then
+        If fNewVal > fval Then
+          fNewVal = fval - 0.5
+        Endif
+      Else
+        If fVal = Thermostat.NO_TEMP Then
+          Try fVal = Devices.GetCurrentValueForDevice(Thermostat.GetHeatSensor(iHeatingId), 1)
+        Endif
+
+        fNewVal = fval - 0.5
+      Endif
+    Else
+      fNewVal = fval - 0.5
+    Endif
+
+  Else
+    Error.Raise("ERROR: Unsupported operator '" & cData["operator"] & "'")
+  Endif
+
+  Thermostat.SetDerogateHeating(iScenarioId, iHeatingId, fNewVal)
+  SetReply(0, True)
+
+Catch
+  SetReply(0, False, Error.Text)
 
 End
 
@@ -2565,7 +2617,13 @@ End
 '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Private Sub Call_Thermostat_GetDerogateHeating(cData As Collection)
 
-  ' cData["heating_id"] = CInt(iHeatingId)
+  Dim iHeatingId As Integer = CInt(cData["heating_id"])
+  Dim fDerVal As Float = Thermostat.GetDerogateHeating(iHeatingId)
+
+  SetReply(0, fDerVal)
+
+Catch
+  SetReply(-1, Null)
 
 End
 

--- a/DomotiGaServer3/.src/CJSONRPC.class
+++ b/DomotiGaServer3/.src/CJSONRPC.class
@@ -2554,9 +2554,61 @@ End
 '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Private Sub Call_Thermostat_DerogateHeating(cData As Collection)
 
-  ' cData["scenario_id"] = CInt(iScenarioId)
-  ' cData["heating_id"] = CInt(iHeatingId)
-  ' cData["operator"] = JSONToEmptyString(sOperator)
+  Dim iScenarioId As Integer = CInt(cData["scenario_id"])
+  Dim iHeatingId As Integer = CInt(cData["heating_id"])
+  Dim fNewVal, fVal, fDerVal As Float
+
+  fVal = Thermostat.GetRequestedTempForHeating(iScenarioId, iHeatingId)
+  fDerVal = Thermostat.GetDerogateHeating(iHeatingId)
+  If fDerVal <> Thermostat.NO_TEMP Then
+    fval = fderval
+  Endif
+  If cData["operator"] = "+" Then
+    If fDerVal = Thermostat.NO_TEMP Then
+      fNewVal = Thermostat.GetNextRequestedTempForHeating(iScenarioId, iHeatingId)
+      If fNewVal <> Thermostat.NO_TEMP Then
+        If fNewVal < fval Then
+          fNewVal = fval + 0.5
+        Endif
+      Else
+        If fVal = Thermostat.NO_TEMP Then
+          Try fVal = Devices.GetCurrentValueForDevice(Thermostat.GetHeatSensor(iHeatingId), 1)
+        Endif
+
+        fNewVal = fval + 0.5
+      Endif
+    Else
+      fNewVal = fval + 0.5
+    Endif
+
+  Else If cData["operator"] = "-" Then
+
+    If fDerVal = Thermostat.NO_TEMP Then
+      fNewVal = Thermostat.GetNextRequestedTempForHeating(iScenarioId, iHeatingId)
+      If fNewVal <> Thermostat.NO_TEMP Then
+        If fNewVal > fval Then
+          fNewVal = fval - 0.5
+        Endif
+      Else
+        If fVal = Thermostat.NO_TEMP Then
+          Try fVal = Devices.GetCurrentValueForDevice(Thermostat.GetHeatSensor(iHeatingId), 1)
+        Endif
+
+        fNewVal = fval - 0.5
+      Endif
+    Else
+      fNewVal = fval - 0.5
+    Endif
+
+  Else
+    Error.Raise("ERROR: Unsupported operator '" & cData["operator"] & "'")
+  Endif
+
+  Thermostat.SetDerogateHeating(iScenarioId, iHeatingId, fNewVal)
+  SetReply(0, True)
+
+Catch
+  SetReply(0, False, Error.Text)
 
 End
 
@@ -2565,7 +2617,13 @@ End
 '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Private Sub Call_Thermostat_GetDerogateHeating(cData As Collection)
 
-  ' cData["heating_id"] = CInt(iHeatingId)
+  Dim iHeatingId As Integer = CInt(cData["heating_id"])
+  Dim fDerVal As Float = Thermostat.GetDerogateHeating(iHeatingId)
+
+  SetReply(0, fDerVal)
+
+Catch
+  SetReply(-1, Null)
 
 End
 


### PR DESCRIPTION
Fix for [Thermostat Issue after upgrade to 1.0.018](https://domotiga.nl/boards/1/topics/4618). 
Ported relevant code from CXMLRPC.class to CJSONRPC.class.

Compiles fine, could not test it.
