### PR TITLE
Fixed: Do not hang when a global var template points to a non-existing g...

### DIFF
--- a/DomotiGa3/.src/Events.module
+++ b/DomotiGa3/.src/Events.module
@@ -737,20 +737,33 @@ Private Sub ParseText(sText As String) As String
   Dim sTag As String
   Dim sReplace As String
   Dim rMatch As New RegExp
+  Dim iLimit As Integer = 10
 
   ' Replace global vars
   rMatch.Compile("<%([^>]+)%>")
   Do While True
     rMatch.Exec(sText)
     If rMatch.Count > 0 Then
+
+      ' If the RegEx did match check for global var
       sTag = rMatch[1].Text
       Try sReplace = Main.GetGlobalVar(sTag)
-      If sReplace Then
-        sText = Replace(sText, "<%" & sTag & "%>", sReplace)
-      Else
+      If IsNull(sReplace) Then
         If Main.bEventsDebug Then Main.WriteLog("ERROR: Could not find global variable for <%" & sTag & "%>")
+        sReplace = "<Unknown global var " & sTag & ">"
       Endif
+
+      ' Replace the template; rMatch[0] is the whole match
+      sText = Left(sText, rMatch[0].Offset) & sReplace & Mid(sText, rMatch[0].Offset + Len(rMatch[0].Text) + 1)
     Else
+      ' No Match
+      Break
+    Endif
+
+    ' Should never happen but better check instead of hang
+    iLimit -= 1
+    If iLimit <= 0 Then
+      Main.WriteDebugLog("ERROR: Broke loop in Events.ParseText parsing '" & sText & "'")
       Break
     Endif
   Loop
@@ -766,6 +779,7 @@ Private Sub ReplaceDeviceVar(sText As String) As String
   Dim sReplace As String
   Dim rMatch As New RegExp
   Dim sElt As String[]
+  Dim iLimit As Integer = 10
 
   ' Replace device values
   rMatch.Compile("<\\$([^>]+)\\$>")
@@ -783,8 +797,18 @@ Private Sub ReplaceDeviceVar(sText As String) As String
         iDeviceId = CInt(sTag)
         sReplace = Devices.GetCurrentValueForDevice(iDeviceId, 1)
       Endif
-      sText = Replace(sText, "<$" & sTag & "$>", sReplace)
+
+      ' Replace the template; rMatch[0] is the whole match
+      sText = Left(sText, rMatch[0].Offset) & sReplace & Mid(sText, rMatch[0].Offset + Len(rMatch[0].Text) + 1)
     Else
+      ' No match
+      Break
+    Endif
+
+    ' Should never happen but better check instead of hang
+    iLimit -= 1
+    If iLimit <= 0 Then
+      Main.WriteDebugLog("ERROR: Broke loop in Events.ReplaceDeviceVar parsing '" & sText & "'")
       Break
     Endif
   Loop

--- a/DomotiGaServer3/.src/Events.module
+++ b/DomotiGaServer3/.src/Events.module
@@ -737,20 +737,33 @@ Private Sub ParseText(sText As String) As String
   Dim sTag As String
   Dim sReplace As String
   Dim rMatch As New RegExp
+  Dim iLimit As Integer = 10
 
   ' Replace global vars
   rMatch.Compile("<%([^>]+)%>")
   Do While True
     rMatch.Exec(sText)
     If rMatch.Count > 0 Then
+
+      ' If the RegEx did match check for global var
       sTag = rMatch[1].Text
       Try sReplace = Main.GetGlobalVar(sTag)
-      If sReplace Then
-        sText = Replace(sText, "<%" & sTag & "%>", sReplace)
-      Else
+      If IsNull(sReplace) Then
         If Main.bEventsDebug Then Main.WriteLog("ERROR: Could not find global variable for <%" & sTag & "%>")
+        sReplace = "<Unknown global var " & sTag & ">"
       Endif
+
+      ' Replace the template; rMatch[0] is the whole match
+      sText = Left(sText, rMatch[0].Offset) & sReplace & Mid(sText, rMatch[0].Offset + Len(rMatch[0].Text) + 1)
     Else
+      ' No Match
+      Break
+    Endif
+
+    ' Should never happen but better check instead of hang
+    iLimit -= 1
+    If iLimit <= 0 Then
+      Main.WriteDebugLog("ERROR: Broke loop in Events.ParseText parsing '" & sText & "'")
       Break
     Endif
   Loop
@@ -766,6 +779,7 @@ Private Sub ReplaceDeviceVar(sText As String) As String
   Dim sReplace As String
   Dim rMatch As New RegExp
   Dim sElt As String[]
+  Dim iLimit As Integer = 10
 
   ' Replace device values
   rMatch.Compile("<\\$([^>]+)\\$>")
@@ -783,8 +797,18 @@ Private Sub ReplaceDeviceVar(sText As String) As String
         iDeviceId = CInt(sTag)
         sReplace = Devices.GetCurrentValueForDevice(iDeviceId, 1)
       Endif
-      sText = Replace(sText, "<$" & sTag & "$>", sReplace)
+
+      ' Replace the template; rMatch[0] is the whole match
+      sText = Left(sText, rMatch[0].Offset) & sReplace & Mid(sText, rMatch[0].Offset + Len(rMatch[0].Text) + 1)
     Else
+      ' No match
+      Break
+    Endif
+
+    ' Should never happen but better check instead of hang
+    iLimit -= 1
+    If iLimit <= 0 Then
+      Main.WriteDebugLog("ERROR: Broke loop in Events.ReplaceDeviceVar parsing '" & sText & "'")
       Break
     Endif
   Loop


### PR DESCRIPTION
Fix for hang if you give a global variable template and the global variable does not exist.

The iLimit should not be needed but like the comment says "better check instead of hang"
