### PR TITLE
Several MySensor minor fixes and improvements take #2

### DIFF
--- a/DomotiGa3/.src/CMySensors.class
+++ b/DomotiGa3/.src/CMySensors.class
@@ -67,6 +67,7 @@ Public bSimulate As Boolean
 Private sTxMsgQueue As New String[]     ' Outgoing message queue
 Private bInterfaceBusy As Boolean       ' waiting for delay timer to finish
 Private bGatewayReady As Boolean        ' Flag to indicate we received the Gateway ready message
+Private sGatewayVersion As String       ' Version of the gateway retrieved using I_VERSION, for example 1.4.1
 
 ' counters to prevent logfile to fill up the disk
 Private iReadErrorCount As Integer
@@ -331,7 +332,7 @@ Public Sub SendCommand(sAddress As String, sCmd As String)
   rValue.Compile("V_[A-Z0-9]+)")
   For Each rValues
     ' Try to get the sub-type from the description
-    If rValues!description And rValue.Exec(rValues!description) Then
+    If rValues!description And If rValue.Exec(rValues!description) Then
       sValue = rValue[1].Text
       Select sValue
         Case "V_LIGHT"
@@ -435,7 +436,7 @@ End
 '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Public Function SendMessage(sMsgText As String)
 
-  WriteMyDebugLog("> " & sMsgText, True)
+  WriteMyDebugLog("> " & Trim(sMsgText))
 
   If $sInterface = "tcp" Then
     ' send the message to the tcp stream
@@ -730,6 +731,11 @@ End
 ' Process a character received by MySensorsTCP_Read or MySensorsSer_Read
 Private Sub ProcessReceivedChar(bTemp As Byte)
 
+  ' at start-up we get sometimes a stream of null characters
+  If Not bGatewayReady And If bTemp = 0 Then
+    Return
+  Endif
+
   ' relay incoming data to relay port
   If $bRelayEnabled Then Try Write #hMySensorsRelaySocket, bTemp As Byte
 
@@ -792,7 +798,7 @@ Private Sub Decode_Messages(sMsgText As String)
   End Select
 
   Catch
-  Main.WriteLog(LogLabel & "ERROR: '" & Error.Text & "' at '" & Error.Where & "'")
+    Main.WriteLog(LogLabel & "ERROR parsing '" & sMsgText & "': '" & Error.Text & "' at '" & Error.Where & "'")
     WriteMyDebugLog("Ignore: " & sMsgText)
 
 End
@@ -955,7 +961,8 @@ End
 ' Handle I_VERSION Internal message
 Private Sub HandleVersion(MySenMsg As MySensorMessage)
 
-  WriteMyDebugLog("No support for I_VERSION Internal message yet.")
+  sGatewayVersion = MySenMsg.payload
+  WriteMyDebugLog("Version of the MySensors gateway is '" & sGatewayVersion & "'.")
 
 End
 


### PR DESCRIPTION
Problem in MySensors.SendCommand, hopefully fixes @dallco's problem.
Fixed: Remove ^M from MySensors transmit data logging
Fixed: Ignore MySensors stream of null character at start-up
Added: Code to handle MySensors I_VERSION message