### PR TITLE
Fixed : "Type mismatch" if JeeNode returns 0 for low battery

### DIFF
--- a/DomotiGa3/.src/CJeeLabs.class
+++ b/DomotiGa3/.src/CJeeLabs.class
@@ -428,7 +428,7 @@ Private Sub ProcessReceivedPacket(sData As String)
   ' parse each line
   For Each sLine In Split(sData, "\n")
     ' parse sensor data
-    aScan = Scan(sLine, "* * * * * *")
+    aScan = Scan(Trim(sLine), "* * * * * *")
     If aScan.Count = 6 Then
       iSensorId = aScan[1]
       iSensorId = IIf(iSensorId > 31, iSensorId - 32, iSensorId)

--- a/DomotiGaServer3/.src/CJeeLabs.class
+++ b/DomotiGaServer3/.src/CJeeLabs.class
@@ -428,7 +428,7 @@ Private Sub ProcessReceivedPacket(sData As String)
   ' parse each line
   For Each sLine In Split(sData, "\n")
     ' parse sensor data
-    aScan = Scan(sLine, "* * * * * *")
+    aScan = Scan(Trim(sLine), "* * * * * *")
     If aScan.Count = 6 Then
       iSensorId = aScan[1]
       iSensorId = IIf(iSensorId > 31, iSensorId - 32, iSensorId)


### PR DESCRIPTION
Remove unwanted ASCII characters before parsing the received string from JeeNode.